### PR TITLE
Add the ability to select which command gets executed when clicking inventory equipment slots

### DIFF
--- a/src/main/kotlin/com/skysoft/config/InventoryFeatureConfig.kt
+++ b/src/main/kotlin/com/skysoft/config/InventoryFeatureConfig.kt
@@ -332,6 +332,22 @@ class InventoryEquipmentConfig {
     @field:ConfigOption(name = "Enabled", desc = "Show cached equipment beside your inventory.")
     @field:ConfigEditorBoolean
     var enabled = true
+
+    @JvmField
+    @field:Expose
+    @field:ConfigOption(name = "Click Action", desc = "Choose what happens when clicking an inventory equipment slot.")
+    @field:ConfigEditorDropdown
+    var clickAction = InventoryEquipmentClickAction.STATS
+}
+
+enum class InventoryEquipmentClickAction(private val displayName: String, val command: String?) {
+    NOTHING("Nothing", null),
+    STATS("/stats", "stats"),
+    EQUIPMENT("/equipment", "equipment"),
+    LOADOUT("/loadout", "loadout"),
+    ;
+
+    override fun toString(): String = displayName
 }
 
 class InventoryButtonsConfig {

--- a/src/main/kotlin/com/skysoft/features/inventory/InventoryEquipmentLayout.kt
+++ b/src/main/kotlin/com/skysoft/features/inventory/InventoryEquipmentLayout.kt
@@ -70,8 +70,10 @@ internal fun handleInventoryEquipmentMouseClick(
     if (inventoryEquipmentSlotGeometry(screen).none { it.screenBounds.contains(mouseX, mouseY) }) {
         return InputHandlingResult.IGNORED
     }
-    if (isStatsOpenClick(click) && screen.menu.carried.isEmpty) {
-        Minecraft.getInstance().connection?.sendCommand("stats")
+    if (isEquipmentCommandClick(click) && screen.menu.carried.isEmpty) {
+        inventoryEquipmentConfig.clickAction.command?.let { command ->
+            Minecraft.getInstance().connection?.sendCommand(command)
+        }
     }
     return InputHandlingResult.CONSUMED
 }
@@ -164,7 +166,7 @@ private fun drawInventoryEquipmentSlotRightEdgeColumn(
     )
 }
 
-private fun isStatsOpenClick(click: MouseButtonEvent): Boolean =
+private fun isEquipmentCommandClick(click: MouseButtonEvent): Boolean =
     click.button() == GLFW.GLFW_MOUSE_BUTTON_LEFT ||
         click.button() == GLFW.GLFW_MOUSE_BUTTON_RIGHT
 

--- a/src/main/kotlin/com/skysoft/features/inventory/InventoryEquipmentRenderer.kt
+++ b/src/main/kotlin/com/skysoft/features/inventory/InventoryEquipmentRenderer.kt
@@ -16,7 +16,6 @@ import net.minecraft.world.entity.player.Player
 import net.minecraft.world.inventory.Slot
 import net.minecraft.world.item.ItemStack
 
-private val openStatsTooltip = Component.literal("Open /stats").withStyle(ChatFormatting.GRAY)
 private val equipmentSlotLayouts = IdentityHashMap<AbstractContainerScreen<*>, InventoryEquipmentSlotLayout>()
 private val slotHighlightBackSprite = Identifier.withDefaultNamespace("container/slot_highlight_back")
 private val slotHighlightFrontSprite = Identifier.withDefaultNamespace("container/slot_highlight_front")
@@ -45,11 +44,17 @@ internal fun renderInventoryEquipment(
             if (!stack.isEmpty) {
                 context.setTooltipForNextFrame(Minecraft.getInstance().font, stack, mouseX, mouseY)
             } else {
-                context.setTooltipForNextFrame(Minecraft.getInstance().font, openStatsTooltip, mouseX, mouseY)
+                inventoryEquipmentClickTooltip()?.let { tooltip ->
+                    context.setTooltipForNextFrame(Minecraft.getInstance().font, tooltip, mouseX, mouseY)
+                }
             }
         }
     }
 }
+
+private fun inventoryEquipmentClickTooltip(): Component? =
+    inventoryEquipmentConfig.clickAction.command
+        ?.let { command -> Component.literal("Open /$command").withStyle(ChatFormatting.GRAY) }
 
 internal fun restoreInventoryEquipmentSlots(screen: AbstractContainerScreen<*>) {
     equipmentSlotLayouts.remove(screen)


### PR DESCRIPTION
Currently when clicking inventory equipment slots, the /stats command is being executed.

I want it to open /loadout or /equipment instead, other users may not want to do anything at all.

Thats why I added the setting, which allows selecting which command gets executed.