### PR TITLE
Prevent media keys toggling item list

### DIFF
--- a/src/main/kotlin/com/skysoft/features/inventory/itemlist/ItemListController.kt
+++ b/src/main/kotlin/com/skysoft/features/inventory/itemlist/ItemListController.kt
@@ -520,7 +520,10 @@ object ItemListController {
                 InputHandlingResult.CONSUMED
             }
         }
-        if (event.key() == config.settings.visibilityKey && config.enabled && HypixelLocationState.onHypixel) {
+        if (config.settings.visibilityKey != GLFW.GLFW_KEY_UNKNOWN &&
+            event.key() == config.settings.visibilityKey &&
+            config.enabled && HypixelLocationState.onHypixel
+        ) {
             ItemListState.isTemporarilyHidden = !ItemListState.isTemporarilyHidden
             searchField.focused = false
             return InputHandlingResult.CONSUMED


### PR DESCRIPTION
Cause: both unbound keybinds and unsupported media keys use GLFW_KEY_UNKNOWN (-1), so media keys accidentally matched an unbound visibility key.

The Item List now rejects an unknown visibility binding before comparing keys.