### PR TITLE
Add rift equipment click action

### DIFF
--- a/src/main/kotlin/com/skysoft/config/InventoryEquipmentConfig.kt
+++ b/src/main/kotlin/com/skysoft/config/InventoryEquipmentConfig.kt
@@ -1,6 +1,7 @@
 package com.skysoft.config
 
 import com.google.gson.annotations.Expose
+import io.github.notenoughupdates.moulconfig.annotations.Accordion
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorDropdown
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
@@ -14,9 +15,26 @@ class InventoryEquipmentConfig {
 
     @JvmField
     @field:Expose
+    @field:ConfigOption(name = "Settings", desc = "Inventory equipment click settings.")
+    @field:Accordion
+    val settings = InventoryEquipmentSettingsConfig()
+}
+
+class InventoryEquipmentSettingsConfig {
+    @JvmField
+    @field:Expose
     @field:ConfigOption(name = "Click Action", desc = "Choose what happens when clicking an inventory equipment slot.")
     @field:ConfigEditorDropdown
     var clickAction = InventoryEquipmentClickAction.STATS
+
+    @JvmField
+    @field:Expose
+    @field:ConfigOption(
+        name = "Rift Click Action",
+        desc = "Choose what happens when clicking an inventory equipment slot inside The Rift.",
+    )
+    @field:ConfigEditorDropdown
+    var riftClickAction = RiftInventoryEquipmentClickAction.STATS
 }
 
 enum class InventoryEquipmentClickAction(private val displayName: String, val command: String?) {
@@ -24,6 +42,14 @@ enum class InventoryEquipmentClickAction(private val displayName: String, val co
     STATS("/stats", "stats"),
     EQUIPMENT("/equipment", "equipment"),
     LOADOUT("/loadout", "loadout"),
+    ;
+
+    override fun toString(): String = displayName
+}
+
+enum class RiftInventoryEquipmentClickAction(private val displayName: String, val command: String?) {
+    NOTHING("Nothing", null),
+    STATS("/stats", "stats"),
     ;
 
     override fun toString(): String = displayName

--- a/src/main/kotlin/com/skysoft/config/SkysoftConfigMigrations.kt
+++ b/src/main/kotlin/com/skysoft/config/SkysoftConfigMigrations.kt
@@ -210,6 +210,8 @@ internal object SkysoftConfigMigrations {
             inventoryButtonsJson.moveFieldsInto("settings", INVENTORY_BUTTON_SETTINGS_FIELDS)
             inventoryButtonsJson.moveFieldsInto("details", INVENTORY_BUTTON_DETAILS_FIELDS)
         }
+        inventoryJson.getObjectOrNull("inventoryEquipment")
+            ?.moveFieldsInto("settings", INVENTORY_EQUIPMENT_SETTINGS_FIELDS)
         inventoryJson.getObjectOrNull("fullInventory")?.let { fullInventoryJson ->
             fullInventoryJson.moveFieldsInto("settings", FULL_INVENTORY_SETTINGS_FIELDS)
             fullInventoryJson.moveFieldsInto("details", FULL_INVENTORY_DETAILS_FIELDS)
@@ -379,6 +381,7 @@ internal object SkysoftConfigMigrations {
     private val STORAGE_OVERLAY_DETAILS_FIELDS = listOf("columns", "height", "scrollSpeed")
     private val INVENTORY_BUTTON_SETTINGS_FIELDS = listOf("clickType")
     private val INVENTORY_BUTTON_DETAILS_FIELDS = listOf("tooltipDelay")
+    private val INVENTORY_EQUIPMENT_SETTINGS_FIELDS = listOf("clickAction")
     private val FULL_INVENTORY_SETTINGS_FIELDS = listOf("emptySlots")
     private val FULL_INVENTORY_DETAILS_FIELDS = listOf("playSound")
     private val SLOT_BINDING_SETTINGS_FIELDS = listOf("bindingKey")

--- a/src/main/kotlin/com/skysoft/features/inventory/InventoryEquipment.kt
+++ b/src/main/kotlin/com/skysoft/features/inventory/InventoryEquipment.kt
@@ -1,6 +1,7 @@
 package com.skysoft.features.inventory
 
 import com.skysoft.config.SkysoftConfigGui
+import com.skysoft.data.SkyBlockIsland
 import com.skysoft.data.hypixel.HypixelLocationState
 import com.skysoft.data.hypixel.SkyBlockProfileApi
 import com.skysoft.utils.input.InputHandlingResult
@@ -50,3 +51,10 @@ internal val inventoryEquipmentConfig
 
 internal fun isInventoryEquipmentAvailable(): Boolean =
     inventoryEquipmentConfig.enabled && HypixelLocationState.inSkyBlock
+
+internal fun inventoryEquipmentClickCommand(): String? =
+    if (SkyBlockIsland.THE_RIFT.isInIsland()) {
+        inventoryEquipmentConfig.settings.riftClickAction.command
+    } else {
+        inventoryEquipmentConfig.settings.clickAction.command
+    }

--- a/src/main/kotlin/com/skysoft/features/inventory/InventoryEquipmentLayout.kt
+++ b/src/main/kotlin/com/skysoft/features/inventory/InventoryEquipmentLayout.kt
@@ -71,7 +71,7 @@ internal fun handleInventoryEquipmentMouseClick(
         return InputHandlingResult.IGNORED
     }
     if (isEquipmentCommandClick(click) && screen.menu.carried.isEmpty) {
-        inventoryEquipmentConfig.clickAction.command?.let { command ->
+        inventoryEquipmentClickCommand()?.let { command ->
             Minecraft.getInstance().connection?.sendCommand(command)
         }
     }

--- a/src/main/kotlin/com/skysoft/features/inventory/InventoryEquipmentRenderer.kt
+++ b/src/main/kotlin/com/skysoft/features/inventory/InventoryEquipmentRenderer.kt
@@ -54,7 +54,7 @@ internal fun renderInventoryEquipment(
 }
 
 private fun inventoryEquipmentClickTooltip(): Component? =
-    inventoryEquipmentConfig.clickAction.command
+    inventoryEquipmentClickCommand()
         ?.let { command -> Component.literal("Open /$command").withStyle(ChatFormatting.GRAY) }
 
 internal fun restoreInventoryEquipmentSlots(screen: AbstractContainerScreen<*>) {


### PR DESCRIPTION
Reason:
- In rift the /equipment and /loadout commands are disabled.