### PR TITLE
Feature/sack hud v2

### DIFF
--- a/src/main/kotlin/com/skysoft/SkysoftFeatureRegistrations.kt
+++ b/src/main/kotlin/com/skysoft/SkysoftFeatureRegistrations.kt
@@ -63,6 +63,7 @@ import com.skysoft.features.inventory.PriceTooltipRawCraftCosts
 import com.skysoft.features.inventory.PriceTooltips
 import com.skysoft.features.inventory.SlotLockManager
 import com.skysoft.features.inventory.sacks.SackDisplay
+import com.skysoft.features.inventory.sacks.SackHud
 import com.skysoft.features.inventory.SmoothSwapping
 import com.skysoft.features.inventory.StorageCache
 import com.skysoft.features.inventory.StorageOverlayController
@@ -177,6 +178,7 @@ internal object SkysoftFeatureRegistrations {
         register("Price Tooltip Raw Craft Costs", PriceTooltipRawCraftCosts::register)
         register("Price Tooltips", PriceTooltips::register)
         register("Sack Display", SackDisplay::register)
+        register("Sack HUD", SackHud::register)
         register("Item Change Log", ItemChangeLog::register)
         register("Duplicate Enchantment Tooltip Fix", DuplicateEnchantmentTooltipFix::register)
         register("Max Enchant Chroma", MaxEnchantChroma::register)

--- a/src/main/kotlin/com/skysoft/SkysoftFeatureRegistrations.kt
+++ b/src/main/kotlin/com/skysoft/SkysoftFeatureRegistrations.kt
@@ -178,7 +178,7 @@ internal object SkysoftFeatureRegistrations {
         register("Price Tooltip Raw Craft Costs", PriceTooltipRawCraftCosts::register)
         register("Price Tooltips", PriceTooltips::register)
         register("Sack Display", SackDisplay::register)
-        register("Sack HUD", SackHud::register)
+        register("Sacks Tracker", SackHud::register)
         register("Item Change Log", ItemChangeLog::register)
         register("Duplicate Enchantment Tooltip Fix", DuplicateEnchantmentTooltipFix::register)
         register("Max Enchant Chroma", MaxEnchantChroma::register)

--- a/src/main/kotlin/com/skysoft/config/InventoryFeatureConfig.kt
+++ b/src/main/kotlin/com/skysoft/config/InventoryFeatureConfig.kt
@@ -32,6 +32,12 @@ class InventoryFeatureConfig : ConfigRepairable {
 
     @JvmField
     @field:Expose
+    @field:ConfigGames(SKYBLOCK)
+    @field:Category(name = "Sack HUD", desc = "Show selected sack item quantities on a movable HUD.")
+    val sackHud = SackHudConfig()
+
+    @JvmField
+    @field:Expose
     @field:Category(name = "Tooltip Scroll", desc = "Move oversized item tooltips.")
     val tooltipScroll = TooltipScrollConfig()
 
@@ -156,6 +162,7 @@ class InventoryFeatureConfig : ConfigRepairable {
         itemList,
         bazaar,
         sackDisplay,
+        sackHud,
         tooltipScroll,
         priceTooltips,
         smoothSwapping,

--- a/src/main/kotlin/com/skysoft/config/InventoryFeatureConfig.kt
+++ b/src/main/kotlin/com/skysoft/config/InventoryFeatureConfig.kt
@@ -33,7 +33,7 @@ class InventoryFeatureConfig : ConfigRepairable {
     @JvmField
     @field:Expose
     @field:ConfigGames(SKYBLOCK)
-    @field:Category(name = "Sack HUD", desc = "Show selected sack item quantities on a movable HUD.")
+    @field:Category(name = "Sacks Tracker", desc = "Show selected sack item quantities on a movable HUD.")
     val sackHud = SackHudConfig()
 
     @JvmField

--- a/src/main/kotlin/com/skysoft/config/SackHudConfig.kt
+++ b/src/main/kotlin/com/skysoft/config/SackHudConfig.kt
@@ -21,14 +21,14 @@ class SackHudConfig : ConfigRepairable {
 
     @JvmField
     @field:Expose
-    @field:ConfigOption(name = "Settings", desc = "Sack HUD settings.")
+    @field:ConfigOption(name = "Settings", desc = "Sacks Tracker settings.")
     @field:Accordion
     @field:ConfigVisibleIf("enabled")
     val settings = SackHudSettingsConfig()
 
     @JvmField
     @field:Expose
-    @field:ConfigOption(name = "Details", desc = "Sack HUD appearance.")
+    @field:ConfigOption(name = "Details", desc = "Sacks Tracker appearance.")
     @field:Accordion
     @field:ConfigVisibleIf("enabled")
     val details = SackHudDetailsConfig()
@@ -67,18 +67,18 @@ class SackHudSettingsConfig {
 
     @JvmField
     @field:Expose
-    @field:ConfigOption(name = "Only in Menus", desc = "Only show the Sack HUD while a container menu is open.")
+    @field:ConfigOption(name = "Only in Menus", desc = "Only show the Sacks Tracker while a container menu is open.")
     @field:ConfigEditorBoolean
     var isOnlyInMenus = false
 
     @JvmField
     @field:Expose
-    @field:ConfigOption(name = "Hide When Empty", desc = "Hide the Sack HUD when no items are being tracked.")
+    @field:ConfigOption(name = "Hide When Empty", desc = "Hide the Sacks Tracker when no items are being tracked.")
     @field:ConfigEditorBoolean
     var hideWhenEmpty = false
 
     @JvmField
-    @field:ConfigOption(name = "Clear Tracked Items", desc = "Remove every item from the Sack HUD.")
+    @field:ConfigOption(name = "Clear Tracked Items", desc = "Remove every item from the Sacks Tracker.")
     @field:ConfigEditorButton(buttonText = "Clear")
     val clearTrackedItems = Runnable {
         val config = SkysoftConfigGui.config().inventory.sackHud
@@ -91,7 +91,7 @@ class SackHudSettingsConfig {
 class SackHudDetailsConfig {
     @JvmField
     @field:Expose
-    @field:ConfigOption(name = "Show Title", desc = "Show the §eSack HUD§7 title above tracked items.")
+    @field:ConfigOption(name = "Show Title", desc = "Show the §eSacks Tracker§7 title above tracked items.")
     @field:ConfigEditorBoolean
     var showTitle = true
 
@@ -109,7 +109,7 @@ class SackHudDetailsConfig {
 
     @JvmField
     @field:Expose
-    @field:ConfigOption(name = "Show Background", desc = "Draw a dark background behind the Sack HUD.")
+    @field:ConfigOption(name = "Show Background", desc = "Draw a dark background behind the Sacks Tracker.")
     @field:ConfigEditorBoolean
     var showBackground = true
 

--- a/src/main/kotlin/com/skysoft/config/SackHudConfig.kt
+++ b/src/main/kotlin/com/skysoft/config/SackHudConfig.kt
@@ -91,6 +91,18 @@ class SackHudSettingsConfig {
 class SackHudDetailsConfig {
     @JvmField
     @field:Expose
+    @field:ConfigOption(name = "Show Title", desc = "Show the §eSack HUD§7 title above tracked items.")
+    @field:ConfigEditorBoolean
+    var showTitle = true
+
+    @JvmField
+    @field:Expose
+    @field:ConfigOption(name = "Show Item Names", desc = "Show item names beside tracked sack amounts.")
+    @field:ConfigEditorBoolean
+    var showItemNames = true
+
+    @JvmField
+    @field:Expose
     @field:ConfigOption(name = "Show Item Icons", desc = "Show item icons beside tracked sack amounts.")
     @field:ConfigEditorBoolean
     var showItemIcons = true

--- a/src/main/kotlin/com/skysoft/config/SackHudConfig.kt
+++ b/src/main/kotlin/com/skysoft/config/SackHudConfig.kt
@@ -1,0 +1,115 @@
+package com.skysoft.config
+
+import com.google.gson.annotations.Expose
+import com.skysoft.config.core.ConfigRepairable
+import com.skysoft.config.core.HudPosition
+import io.github.notenoughupdates.moulconfig.annotations.Accordion
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorButton
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorInfoText
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorSlider
+import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
+import io.github.notenoughupdates.moulconfig.annotations.ConfigVisibleIf
+
+class SackHudConfig : ConfigRepairable {
+    @JvmField
+    @field:Expose
+    @field:ConfigOption(name = "Enabled", desc = "Show a movable HUD of selected sack item quantities.")
+    @field:MainFeatureToggle
+    @field:ConfigEditorBoolean
+    var enabled = false
+
+    @JvmField
+    @field:Expose
+    @field:ConfigOption(name = "Settings", desc = "Sack HUD settings.")
+    @field:Accordion
+    @field:ConfigVisibleIf("enabled")
+    val settings = SackHudSettingsConfig()
+
+    @JvmField
+    @field:Expose
+    @field:ConfigOption(name = "Details", desc = "Sack HUD appearance.")
+    @field:Accordion
+    @field:ConfigVisibleIf("enabled")
+    val details = SackHudDetailsConfig()
+
+    @JvmField
+    @field:Expose
+    val trackedItems: MutableList<String> = mutableListOf()
+
+    @JvmField
+    @field:Expose
+    val position = HudPosition(8, 110, centerX = false, centerY = false).rememberDefault()
+
+    override fun repairLoadedValues() {
+        settings.maximumItems = settings.maximumItems.coerceIn(MINIMUM_ITEMS, MAXIMUM_ITEMS)
+        val repaired = trackedItems.asSequence().map(String::trim).filter(String::isNotEmpty).distinct().toList()
+        trackedItems.clear()
+        trackedItems.addAll(repaired)
+    }
+}
+
+class SackHudSettingsConfig {
+    @JvmField
+    @field:ConfigOption(
+        name = "Tracked Items",
+        desc = "Open any inventory, then use §e[+ Add Item]§7 on the HUD and click an inventory item.\n" +
+            "§eRight-click§7 a row to remove it. Amounts update from sack menus and §e[Sacks]§7 chat messages.",
+    )
+    @field:ConfigEditorInfoText
+    val trackedItemsHelp: Unit = Unit
+
+    @JvmField
+    @field:Expose
+    @field:ConfigOption(name = "Maximum Items", desc = "Maximum tracked sack item rows shown at once.")
+    @field:ConfigEditorSlider(minValue = 1f, maxValue = 20f, minStep = 1f)
+    var maximumItems = 8
+
+    @JvmField
+    @field:Expose
+    @field:ConfigOption(name = "Only in Menus", desc = "Only show the Sack HUD while a container menu is open.")
+    @field:ConfigEditorBoolean
+    var isOnlyInMenus = false
+
+    @JvmField
+    @field:Expose
+    @field:ConfigOption(name = "Hide When Empty", desc = "Hide the Sack HUD when no items are being tracked.")
+    @field:ConfigEditorBoolean
+    var hideWhenEmpty = false
+
+    @JvmField
+    @field:ConfigOption(name = "Clear Tracked Items", desc = "Remove every item from the Sack HUD.")
+    @field:ConfigEditorButton(buttonText = "Clear")
+    val clearTrackedItems = Runnable {
+        val config = SkysoftConfigGui.config().inventory.sackHud
+        if (config.trackedItems.isEmpty()) return@Runnable
+        config.trackedItems.clear()
+        SkysoftConfigGui.config().saveNow()
+    }
+}
+
+class SackHudDetailsConfig {
+    @JvmField
+    @field:Expose
+    @field:ConfigOption(name = "Show Item Icons", desc = "Show item icons beside tracked sack amounts.")
+    @field:ConfigEditorBoolean
+    var showItemIcons = true
+
+    @JvmField
+    @field:Expose
+    @field:ConfigOption(name = "Show Background", desc = "Draw a dark background behind the Sack HUD.")
+    @field:ConfigEditorBoolean
+    var showBackground = true
+
+    @JvmField
+    @field:Expose
+    @field:ConfigOption(
+        name = "Highlight Changes",
+        desc = "Briefly highlight amounts when §e[Sacks]§7 chat updates them.",
+    )
+    @field:ConfigEditorBoolean
+    var highlightChanges = true
+}
+
+private const val MINIMUM_ITEMS = 1
+private const val MAXIMUM_ITEMS = 20

--- a/src/main/kotlin/com/skysoft/features/inventory/sacks/SackHud.kt
+++ b/src/main/kotlin/com/skysoft/features/inventory/sacks/SackHud.kt
@@ -33,14 +33,14 @@ internal var sackHudHovered = false
 internal val sackHudChangeHighlights = mutableMapOf<String, Long>()
 
 private fun registerSackHud() {
-    ProfileStorageApi.registerConsumer("Sack HUD") { sackHudConfig.enabled }
-    SkyBlockDataRepository.Demand.register("Sack HUD") { sackHudConfig.enabled }
+    ProfileStorageApi.registerConsumer("Sacks Tracker") { sackHudConfig.enabled }
+    SkyBlockDataRepository.Demand.register("Sacks Tracker") { sackHudConfig.enabled }
     SkyBlockSackChanges.onChange(
-        "Sack HUD changes",
+        "Sacks Tracker changes",
         isActive = { sackHudConfig.enabled && sackHudConfig.details.highlightChanges },
         listener = ::highlightSackChanges,
     )
-    SkysoftClientEvents.onDisconnect("Sack HUD reset") {
+    SkysoftClientEvents.onDisconnect("Sacks Tracker reset") {
         sackHudAddingItem = false
         sackHudScrollOffset = 0
         sackHudChangeHighlights.clear()
@@ -58,12 +58,12 @@ private fun registerSackHud() {
     )
     HudEditorRegistry.register(object : HudEditorElement {
         override val id: String = "sack_hud"
-        override val label: String = "Sack HUD"
+        override val label: String = "Sacks Tracker"
         override val position get() = sackHudConfig.position
         override val hasEditorBackground: Boolean get() = !sackHudConfig.details.showBackground
         override fun width(): Int = buildSackHudRenderable(inventoryOpen = false).width
         override fun height(): Int = buildSackHudRenderable(inventoryOpen = false).height
-        override fun isVisible(): Boolean = sackHudConfig.enabled
+        override fun isVisible(): Boolean = isSackHudVisible()
         // Pin the left edge so growing quantities expand rightward only.
         override fun absoluteX(width: Int): Int = position.getAbsX0AllowingOverflow(0)
         override fun absoluteY(height: Int): Int = position.getAbsY0AllowingOverflow(0)
@@ -79,7 +79,7 @@ private fun registerSackHud() {
             position.scale += if (scrollY > 0.0) SACK_HUD_EDITOR_SCALE_STEP else -SACK_HUD_EDITOR_SCALE_STEP
             return InputHandlingResult.CONSUMED
         }
-        override fun openConfig() = SkysoftConfigGui.open("Sack HUD")
+        override fun openConfig() = SkysoftConfigGui.open("Sacks Tracker")
     })
 }
 
@@ -103,8 +103,12 @@ internal fun isSackHudVisible(): Boolean {
     if (!sackHudConfig.enabled || !HypixelLocationState.inSkyBlock) return false
     val minecraft = Minecraft.getInstance()
     if (MinecraftClient.isGuiHidden(minecraft)) return false
-    if (sackHudConfig.settings.hideWhenEmpty && sackHudConfig.trackedItems.isEmpty()) return false
-    if (sackHudConfig.settings.isOnlyInMenus && MinecraftClient.screen(minecraft) !is AbstractContainerScreen<*>) {
+    val inInventory = MinecraftClient.screen(minecraft) is AbstractContainerScreen<*>
+    // Keep the HUD in inventories when empty so Hide When Empty does not remove Add Item.
+    if (sackHudConfig.settings.hideWhenEmpty && sackHudConfig.trackedItems.isEmpty() && !inInventory) {
+        return false
+    }
+    if (sackHudConfig.settings.isOnlyInMenus && !inInventory) {
         return false
     }
     return true

--- a/src/main/kotlin/com/skysoft/features/inventory/sacks/SackHud.kt
+++ b/src/main/kotlin/com/skysoft/features/inventory/sacks/SackHud.kt
@@ -1,0 +1,114 @@
+package com.skysoft.features.inventory.sacks
+
+import com.skysoft.config.SkysoftConfigGui
+import com.skysoft.data.ProfileStorageApi
+import com.skysoft.data.hypixel.HypixelLocationState
+import com.skysoft.data.skyblock.SkyBlockDataRepository
+import com.skysoft.data.skyblock.SkyBlockItemNames
+import com.skysoft.data.skyblock.SkyBlockSackChangeBatch
+import com.skysoft.data.skyblock.SkyBlockSackChanges
+import com.skysoft.gui.GuiOverlay
+import com.skysoft.gui.GuiOverlayContextType
+import com.skysoft.gui.GuiOverlayLayer
+import com.skysoft.gui.GuiOverlayRegistry
+import com.skysoft.gui.HudEditorElement
+import com.skysoft.gui.HudEditorRegistry
+import com.skysoft.gui.OverlayControlArea
+import com.skysoft.utils.MinecraftClient
+import com.skysoft.utils.SkysoftClientEvents
+import net.minecraft.client.Minecraft
+import net.minecraft.client.gui.GuiGraphicsExtractor
+import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen
+
+object SackHud {
+    fun register() = registerSackHud()
+}
+
+internal val sackHudConfig get() = SkysoftConfigGui.config().inventory.sackHud
+internal var sackHudAddingItem = false
+internal var sackHudScrollOffset = 0
+internal var sackHudHoveredControl: OverlayControlArea<SackHudControl>? = null
+internal var sackHudHovered = false
+internal val sackHudChangeHighlights = mutableMapOf<String, Long>()
+
+private fun registerSackHud() {
+    ProfileStorageApi.registerConsumer("Sack HUD") { sackHudConfig.enabled }
+    SkyBlockDataRepository.Demand.register("Sack HUD") { sackHudConfig.enabled }
+    SkyBlockSackChanges.onChange(
+        "Sack HUD changes",
+        isActive = { sackHudConfig.enabled && sackHudConfig.details.highlightChanges },
+        listener = ::highlightSackChanges,
+    )
+    SkysoftClientEvents.onDisconnect("Sack HUD reset") {
+        sackHudAddingItem = false
+        sackHudScrollOffset = 0
+        sackHudChangeHighlights.clear()
+        clearSackHudInteraction()
+    }
+    registerSackHudInput()
+    GuiOverlayRegistry.register(
+        GuiOverlay(
+            id = "sack_hud",
+            layer = GuiOverlayLayer.BELOW_SCREEN,
+            contexts = GuiOverlayContextType.entries.toSet(),
+            screenForegroundContexts = GuiOverlayContextType.INVENTORIES,
+            render = { context, _ -> renderSackHud(context) },
+        ),
+    )
+    HudEditorRegistry.register(object : HudEditorElement {
+        override val id: String = "sack_hud"
+        override val label: String = "Sack HUD"
+        override val position get() = sackHudConfig.position
+        override val hasEditorBackground: Boolean get() = !sackHudConfig.details.showBackground
+        override fun width(): Int = buildSackHudRenderable(inventoryOpen = false).width
+        override fun height(): Int = buildSackHudRenderable(inventoryOpen = false).height
+        override fun isVisible(): Boolean = sackHudConfig.enabled
+        override fun renderEditor(context: GuiGraphicsExtractor) =
+            buildSackHudRenderable(inventoryOpen = false).render(context)
+        override fun openConfig() = SkysoftConfigGui.open("Sack HUD")
+    })
+}
+
+private fun highlightSackChanges(batch: SkyBlockSackChangeBatch) {
+    val tracked = sackHudConfig.trackedItems.toSet()
+    if (tracked.isEmpty()) return
+    val now = System.currentTimeMillis()
+    batch.changes.forEach { change ->
+        val itemId = ProfileStorageApi.storage.sackContents.entries
+            .singleOrNull { (_, data) -> data.displayName == change.displayName }
+            ?.key
+            ?: SkyBlockItemNames.itemId(change.displayName)
+            ?: return@forEach
+        if (itemId in tracked) {
+            sackHudChangeHighlights[itemId] = now + SACK_HUD_CHANGE_HIGHLIGHT_MILLIS
+        }
+    }
+}
+
+internal fun isSackHudVisible(): Boolean {
+    if (!sackHudConfig.enabled || !HypixelLocationState.inSkyBlock) return false
+    val minecraft = Minecraft.getInstance()
+    if (MinecraftClient.isGuiHidden(minecraft)) return false
+    if (sackHudConfig.settings.hideWhenEmpty && sackHudConfig.trackedItems.isEmpty()) return false
+    if (sackHudConfig.settings.isOnlyInMenus && MinecraftClient.screen(minecraft) !is AbstractContainerScreen<*>) {
+        return false
+    }
+    return true
+}
+
+internal fun clearSackHudInteraction() {
+    sackHudHoveredControl = null
+    sackHudHovered = false
+}
+
+internal fun sackHudMaximumScrollOffset(itemCount: Int): Int =
+    (itemCount - sackHudConfig.settings.maximumItems.coerceIn(1, SACK_HUD_MAXIMUM_DISPLAY_ITEMS))
+        .coerceAtLeast(0)
+
+internal sealed interface SackHudControl {
+    data object AddItem : SackHudControl
+    data class Item(val itemId: String) : SackHudControl
+}
+
+internal const val SACK_HUD_MAXIMUM_DISPLAY_ITEMS = 20
+internal const val SACK_HUD_CHANGE_HIGHLIGHT_MILLIS = 3_000L

--- a/src/main/kotlin/com/skysoft/features/inventory/sacks/SackHud.kt
+++ b/src/main/kotlin/com/skysoft/features/inventory/sacks/SackHud.kt
@@ -16,6 +16,7 @@ import com.skysoft.gui.HudEditorRegistry
 import com.skysoft.gui.OverlayControlArea
 import com.skysoft.utils.MinecraftClient
 import com.skysoft.utils.SkysoftClientEvents
+import com.skysoft.utils.input.InputHandlingResult
 import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.GuiGraphicsExtractor
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen
@@ -63,8 +64,21 @@ private fun registerSackHud() {
         override fun width(): Int = buildSackHudRenderable(inventoryOpen = false).width
         override fun height(): Int = buildSackHudRenderable(inventoryOpen = false).height
         override fun isVisible(): Boolean = sackHudConfig.enabled
+        // Pin the left edge so growing quantities expand rightward only.
+        override fun absoluteX(width: Int): Int = position.getAbsX0AllowingOverflow(0)
+        override fun absoluteY(height: Int): Int = position.getAbsY0AllowingOverflow(0)
         override fun renderEditor(context: GuiGraphicsExtractor) =
             buildSackHudRenderable(inventoryOpen = false).render(context)
+        override fun applyEditorDrag(deltaX: Int, deltaY: Int): InputHandlingResult {
+            val targetX = position.getAbsX0AllowingOverflow(0) + deltaX
+            val targetY = position.getAbsY0AllowingOverflow(0) + deltaY
+            position.moveToAbsoluteAllowingOverflow(targetX, targetY, 0, 0)
+            return InputHandlingResult.CONSUMED
+        }
+        override fun applyEditorScroll(scrollY: Double): InputHandlingResult {
+            position.scale += if (scrollY > 0.0) SACK_HUD_EDITOR_SCALE_STEP else -SACK_HUD_EDITOR_SCALE_STEP
+            return InputHandlingResult.CONSUMED
+        }
         override fun openConfig() = SkysoftConfigGui.open("Sack HUD")
     })
 }
@@ -112,3 +126,4 @@ internal sealed interface SackHudControl {
 
 internal const val SACK_HUD_MAXIMUM_DISPLAY_ITEMS = 20
 internal const val SACK_HUD_CHANGE_HIGHLIGHT_MILLIS = 3_000L
+private const val SACK_HUD_EDITOR_SCALE_STEP = 0.1f

--- a/src/main/kotlin/com/skysoft/features/inventory/sacks/SackHudControls.kt
+++ b/src/main/kotlin/com/skysoft/features/inventory/sacks/SackHudControls.kt
@@ -20,12 +20,12 @@ internal fun registerSackHudInput() {
     ScreenEvents.BEFORE_INIT.register { _, screen, _, _ ->
         if (screen !is AbstractContainerScreen<*>) return@register
         ScreenMouseEvents.allowMouseClick(screen).register { _, click ->
-            SkysoftErrorBoundary.value("Sack HUD mouse click", true) {
+            SkysoftErrorBoundary.value("Sacks Tracker mouse click", true) {
                 shouldAllowSackHudClick(screen, click)
             }
         }
         ScreenMouseEvents.allowMouseScroll(screen).register { _, mouseX, mouseY, _, verticalAmount ->
-            SkysoftErrorBoundary.value("Sack HUD mouse scroll", true) {
+            SkysoftErrorBoundary.value("Sacks Tracker mouse scroll", true) {
                 InventoryOverlayInput.isPointCovered(screen, mouseX, mouseY) ||
                     !wasSackHudScrollHandled(verticalAmount)
             }

--- a/src/main/kotlin/com/skysoft/features/inventory/sacks/SackHudControls.kt
+++ b/src/main/kotlin/com/skysoft/features/inventory/sacks/SackHudControls.kt
@@ -1,0 +1,118 @@
+package com.skysoft.features.inventory.sacks
+
+import com.skysoft.config.SkysoftConfigGui
+import com.skysoft.data.skyblock.SkyBlockDataRepository
+import com.skysoft.data.skyblock.SkyBlockItemId.skyBlockId
+import com.skysoft.features.inventory.InventoryOverlayInput
+import com.skysoft.features.inventory.itemlist.ItemListViewerScreen
+import com.skysoft.mixin.AbstractContainerScreenAccessor
+import com.skysoft.utils.MinecraftClient
+import com.skysoft.utils.SkysoftErrorBoundary
+import com.skysoft.utils.SoundUtilities
+import net.fabricmc.fabric.api.client.screen.v1.ScreenEvents
+import net.fabricmc.fabric.api.client.screen.v1.ScreenMouseEvents
+import net.minecraft.client.Minecraft
+import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen
+import net.minecraft.client.input.MouseButtonEvent
+import org.lwjgl.glfw.GLFW
+
+internal fun registerSackHudInput() {
+    ScreenEvents.BEFORE_INIT.register { _, screen, _, _ ->
+        if (screen !is AbstractContainerScreen<*>) return@register
+        ScreenMouseEvents.allowMouseClick(screen).register { _, click ->
+            SkysoftErrorBoundary.value("Sack HUD mouse click", true) {
+                shouldAllowSackHudClick(screen, click)
+            }
+        }
+        ScreenMouseEvents.allowMouseScroll(screen).register { _, mouseX, mouseY, _, verticalAmount ->
+            SkysoftErrorBoundary.value("Sack HUD mouse scroll", true) {
+                InventoryOverlayInput.isPointCovered(screen, mouseX, mouseY) ||
+                    !wasSackHudScrollHandled(verticalAmount)
+            }
+        }
+    }
+}
+
+private fun shouldAllowSackHudClick(
+    screen: AbstractContainerScreen<*>,
+    click: MouseButtonEvent,
+): Boolean {
+    if (!isSackHudVisible()) return true
+    if (InventoryOverlayInput.isPointCovered(screen, click.x(), click.y())) return true
+    val control = sackHudHoveredControl?.action
+    val handled = when (control) {
+        SackHudControl.AddItem -> if (click.button() == GLFW.GLFW_MOUSE_BUTTON_LEFT) {
+            sackHudAddingItem = !sackHudAddingItem
+            true
+        } else {
+            false
+        }
+        is SackHudControl.Item -> wasSackHudItemClickHandled(screen, control.itemId, click.button())
+        null -> wasInventoryItemAdded(screen, click.button())
+    }
+    if (handled) SoundUtilities.playClickSound()
+    return !handled
+}
+
+private fun wasInventoryItemAdded(screen: AbstractContainerScreen<*>, button: Int): Boolean {
+    if (!sackHudAddingItem || button != GLFW.GLFW_MOUSE_BUTTON_LEFT) return false
+    val player = Minecraft.getInstance().player ?: return false
+    val slot = (screen as AbstractContainerScreenAccessor).skysoftGetHoveredSlot()
+    val itemId = slot?.takeIf { it.container === player.inventory }?.item?.skyBlockId() ?: return false
+    addSackHudTrackedItem(itemId)
+    sackHudAddingItem = false
+    return true
+}
+
+private fun wasSackHudItemClickHandled(
+    screen: AbstractContainerScreen<*>,
+    itemId: String,
+    button: Int,
+): Boolean = when (button) {
+    GLFW.GLFW_MOUSE_BUTTON_LEFT -> {
+        val connection = Minecraft.getInstance().connection ?: return false
+        val key = SkyBlockDataRepository.itemKey(itemId)
+        val itemName = SkyBlockDataRepository.entry(key)?.displayName
+            ?: com.skysoft.data.ProfileStorageApi.storage.sackContents[itemId]?.displayName
+            ?: return false
+        connection.sendCommand("bz $itemName")
+        MinecraftClient.setScreen(null)
+        true
+    }
+    GLFW.GLFW_MOUSE_BUTTON_RIGHT -> {
+        removeSackHudTrackedItem(itemId)
+        true
+    }
+    GLFW.GLFW_MOUSE_BUTTON_MIDDLE -> if (SkysoftConfigGui.config().inventory.itemList.enabled) {
+        MinecraftClient.setScreen(ItemListViewerScreen(screen, SkyBlockDataRepository.itemKey(itemId)))
+        true
+    } else {
+        false
+    }
+    else -> false
+}
+
+private fun wasSackHudScrollHandled(verticalAmount: Double): Boolean {
+    if (!isSackHudVisible() || !sackHudHovered || verticalAmount == 0.0) return false
+    val maximumOffset = sackHudMaximumScrollOffset(sackHudConfig.trackedItems.size)
+    if (maximumOffset == 0) return false
+    sackHudScrollOffset = (sackHudScrollOffset + if (verticalAmount < 0.0) 1 else -1)
+        .coerceIn(0, maximumOffset)
+    return true
+}
+
+internal fun addSackHudTrackedItem(itemId: String) {
+    if (itemId in sackHudConfig.trackedItems) return
+    sackHudConfig.trackedItems += itemId
+    SkysoftConfigGui.config().saveNow()
+}
+
+internal fun removeSackHudTrackedItem(itemId: String) {
+    if (!sackHudConfig.trackedItems.remove(itemId)) return
+    sackHudChangeHighlights.remove(itemId)
+    sackHudScrollOffset = sackHudScrollOffset.coerceIn(
+        0,
+        sackHudMaximumScrollOffset(sackHudConfig.trackedItems.size),
+    )
+    SkysoftConfigGui.config().saveNow()
+}

--- a/src/main/kotlin/com/skysoft/features/inventory/sacks/SackHudRender.kt
+++ b/src/main/kotlin/com/skysoft/features/inventory/sacks/SackHudRender.kt
@@ -125,6 +125,8 @@ internal fun buildSackHudRenderable(inventoryOpen: Boolean): SackHudRenderable {
         items = displayed,
         hiddenAbove = sackHudScrollOffset,
         hiddenBelow = (sackHudConfig.trackedItems.size - sackHudScrollOffset - displayed.size).coerceAtLeast(0),
+        showTitle = sackHudConfig.details.showTitle,
+        showItemNames = sackHudConfig.details.showItemNames,
         showIcons = sackHudConfig.details.showItemIcons,
         background = sackHudConfig.details.showBackground,
         inventoryOpen = inventoryOpen,
@@ -163,19 +165,23 @@ internal class SackHudRenderable(
     items: List<SackHudItem>,
     private val hiddenAbove: Int,
     private val hiddenBelow: Int,
+    private val showTitle: Boolean,
+    private val showItemNames: Boolean,
     private val showIcons: Boolean,
     private val background: Boolean,
     private val inventoryOpen: Boolean,
     private val addingItem: Boolean,
 ) : GuiRenderable {
     private val padding = if (background) OverlayPanelStyle.PADDING else 0
+    private val compactRows = !showItemNames
     private val rows = items.map { item ->
         SackHudRow(
             item = item,
-            name = item.name.truncateLegacyText(MAXIMUM_ITEM_NAME_LENGTH),
+            name = item.name.truncateLegacyText(MAXIMUM_ITEM_NAME_LENGTH).takeIf { showItemNames }.orEmpty(),
             value = item.displayAmount(),
             stack = item.stack,
             reserveIcon = showIcons,
+            compact = compactRows,
         )
     }
     private val emptyText = if (sackHudConfig.trackedItems.isEmpty()) {
@@ -188,16 +194,18 @@ internal class SackHudRenderable(
         if (hiddenBelow > 0) add("$hiddenBelow more")
     }.joinToString(" §8• §7", prefix = "§7", postfix = if (hiddenAbove > 0 || hiddenBelow > 0) "..." else "")
     private val addLine = if (addingItem) "§a§l[+ Click Inventory Item]" else "§e[+ Add Item]"
+    private val titleText = "§e§lSack HUD"
     private val contentWidth = maxOf(
-        MINIMUM_WIDTH,
-        LegacyTextRenderer.width("§e§lSack HUD"),
+        if (compactRows) COMPACT_MINIMUM_WIDTH else MINIMUM_WIDTH,
+        if (showTitle) LegacyTextRenderer.width(titleText) else 0,
         rows.maxOfOrNull(SackHudRow::width) ?: LegacyTextRenderer.width(emptyText),
         LegacyTextRenderer.width(indicatorText),
         if (inventoryOpen) LegacyTextRenderer.width(addLine) else 0,
     )
 
     override val width: Int = contentWidth + padding * 2
-    override val height: Int = padding * 2 + TITLE_HEIGHT +
+    override val height: Int = padding * 2 +
+        (if (showTitle) TITLE_HEIGHT else 0) +
         (if (rows.isEmpty()) TEXT_ROW_HEIGHT else rows.size * ITEM_ROW_HEIGHT) +
         (if (indicatorText.isEmpty()) 0 else TEXT_ROW_HEIGHT) +
         (if (inventoryOpen) CONTROL_ROW_HEIGHT else 0)
@@ -209,8 +217,10 @@ internal class SackHudRenderable(
     fun renderInteractive(context: GuiGraphicsExtractor, mouseX: Int?, mouseY: Int?): LocalSackHudControl? {
         if (background) OverlayPanelStyle.draw(context, 0, 0, width, height)
         var y = padding
-        LegacyTextRenderer.draw(context, "§e§lSack HUD", padding, y)
-        y += TITLE_HEIGHT
+        if (showTitle) {
+            LegacyTextRenderer.draw(context, titleText, padding, y)
+            y += TITLE_HEIGHT
+        }
         var hovered: LocalSackHudControl? = null
         if (rows.isEmpty()) {
             LegacyTextRenderer.draw(context, emptyText, padding, y)
@@ -263,9 +273,16 @@ private data class SackHudRow(
     val value: String,
     val stack: ItemStack?,
     val reserveIcon: Boolean,
+    val compact: Boolean,
 ) {
-    private val contentOffset = if (reserveIcon) ITEM_TEXT_OFFSET else 0
-    val width: Int = contentOffset + LegacyTextRenderer.width(name) + COLUMN_GAP + LegacyTextRenderer.width(value)
+    private val iconWidth = if (reserveIcon) ITEM_TEXT_OFFSET else 0
+    private val nameWidth = if (name.isEmpty()) 0 else LegacyTextRenderer.width(name)
+    private val valueWidth = LegacyTextRenderer.width(value)
+    val width: Int = if (compact) {
+        iconWidth + (if (reserveIcon) COMPACT_ICON_VALUE_GAP else 0) + valueWidth
+    } else {
+        iconWidth + nameWidth + COLUMN_GAP + valueWidth
+    }
 
     fun renderInteractive(
         context: GuiGraphicsExtractor,
@@ -275,14 +292,22 @@ private data class SackHudRow(
         mouseX: Int?,
         mouseY: Int?,
     ): LocalSackHudControl? {
-        val bounds = Rect(left, y, right - left, ITEM_ROW_HEIGHT)
+        val rowRight = if (compact) left + width else right
+        val bounds = Rect(left, y, (rowRight - left).coerceAtLeast(1), ITEM_ROW_HEIGHT)
         val hovered = mouseX != null && mouseY != null && bounds.contains(mouseX, mouseY)
         if (hovered) {
             context.fill(bounds.x, bounds.y, bounds.x + bounds.width, bounds.y + bounds.height, CONTROL_HOVER_COLOR)
         }
         if (reserveIcon) stack?.let { ItemIconRenderable(it, ICON_SCALE).renderAt(context, left, y) }
-        LegacyTextRenderer.draw(context, name, left + contentOffset, y + ITEM_TEXT_Y_OFFSET)
-        LegacyTextRenderer.draw(context, value, right - LegacyTextRenderer.width(value), y + ITEM_TEXT_Y_OFFSET)
+        if (name.isNotEmpty()) {
+            LegacyTextRenderer.draw(context, name, left + iconWidth, y + ITEM_TEXT_Y_OFFSET)
+        }
+        val valueX = if (compact) {
+            left + iconWidth + if (reserveIcon) COMPACT_ICON_VALUE_GAP else 0
+        } else {
+            rowRight - valueWidth
+        }
+        LegacyTextRenderer.draw(context, value, valueX, y + ITEM_TEXT_Y_OFFSET)
         return LocalSackHudControl(SackHudControl.Item(item.itemId), bounds, emptyList()).takeIf { hovered }
     }
 }
@@ -315,6 +340,7 @@ internal data class LocalSackHudControl(
 
 private const val MAXIMUM_ITEM_NAME_LENGTH = 30
 private const val MINIMUM_WIDTH = 160
+private const val COMPACT_MINIMUM_WIDTH = 36
 private const val TITLE_HEIGHT = 13
 private const val TEXT_ROW_HEIGHT = 11
 private const val ITEM_ROW_HEIGHT = 14
@@ -324,4 +350,5 @@ private const val ITEM_TEXT_Y_OFFSET = 2
 private const val ICON_SCALE = 0.75
 private const val ITEM_TEXT_OFFSET = 14
 private const val COLUMN_GAP = 8
+private const val COMPACT_ICON_VALUE_GAP = 2
 private const val CONTROL_HOVER_COLOR = 0x20FFFFFF

--- a/src/main/kotlin/com/skysoft/features/inventory/sacks/SackHudRender.kt
+++ b/src/main/kotlin/com/skysoft/features/inventory/sacks/SackHudRender.kt
@@ -93,7 +93,7 @@ internal fun renderSackHud(context: GuiGraphicsExtractor) {
                 screenMouseY,
                 actionLines = buildList {
                     add("§eLeft-click §7to open Bazaar")
-                    add("§eRight-click §7to remove from Sack HUD")
+                    add("§eRight-click §7to remove from Sacks Tracker")
                     if (SkysoftConfigGui.config().inventory.itemList.enabled) {
                         add("§eMiddle-click §7to open Item List")
                     }
@@ -197,7 +197,7 @@ internal class SackHudRenderable(
         }.joinToString(" §8• §7", prefix = "§7", postfix = "...")
     }
     private val addLine = if (addingItem) "§a§l[+ Click Inventory Item]" else "§e[+ Add Item]"
-    private val titleText = "§e§lSack HUD"
+    private val titleText = "§e§lSacks Tracker"
     private val contentWidth = maxOf(
         if (compactRows) COMPACT_MINIMUM_WIDTH else MINIMUM_WIDTH,
         if (showTitle) LegacyTextRenderer.width(titleText) else 0,

--- a/src/main/kotlin/com/skysoft/features/inventory/sacks/SackHudRender.kt
+++ b/src/main/kotlin/com/skysoft/features/inventory/sacks/SackHudRender.kt
@@ -1,0 +1,327 @@
+package com.skysoft.features.inventory.sacks
+
+import com.skysoft.config.SkysoftConfigGui
+import com.skysoft.data.ProfileStorageApi
+import com.skysoft.data.skyblock.SkyBlockDataRepository
+import com.skysoft.features.inventory.InventoryOverlayInput
+import com.skysoft.gui.OverlayControlArea
+import com.skysoft.gui.OverlayControlMouse
+import com.skysoft.gui.tooltip.SkysoftNativeTooltip
+import com.skysoft.utils.MinecraftClient
+import com.skysoft.utils.NumberUtilities.addSeparators
+import com.skysoft.utils.TextUtilities.truncateLegacyText
+import com.skysoft.utils.gui.OverlayPanelStyle
+import com.skysoft.utils.gui.Rect
+import com.skysoft.utils.render.LegacyTextRenderer
+import com.skysoft.utils.renderables.GuiRenderable
+import com.skysoft.utils.renderables.primitives.ItemIconRenderable
+import com.skysoft.utils.renderables.renderAt
+import kotlin.math.floor
+import kotlin.math.roundToInt
+import net.minecraft.client.Minecraft
+import net.minecraft.client.gui.GuiGraphicsExtractor
+import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen
+import net.minecraft.world.item.ItemStack
+
+internal fun renderSackHud(context: GuiGraphicsExtractor) {
+    if (!isSackHudVisible()) {
+        if (!sackHudConfig.enabled) sackHudAddingItem = false
+        clearSackHudInteraction()
+        return
+    }
+    val minecraft = Minecraft.getInstance()
+    val inventoryScreen = MinecraftClient.screen(minecraft) as? AbstractContainerScreen<*>
+    val inventoryOpen = inventoryScreen != null
+    if (!inventoryOpen) sackHudAddingItem = false
+    val renderable = buildSackHudRenderable(inventoryOpen)
+    if (renderable.width <= 0 || renderable.height <= 0) {
+        clearSackHudInteraction()
+        return
+    }
+    val window = minecraft.window
+    val mouseX = minecraft.mouseHandler.getScaledXPos(window).toInt()
+    val mouseY = minecraft.mouseHandler.getScaledYPos(window).toInt()
+    val (normalMouseX, normalMouseY) = OverlayControlMouse.normalPoint(mouseX, mouseY)
+    val (screenMouseX, screenMouseY) = OverlayControlMouse.screenPoint(mouseX, mouseY)
+    val interactive = inventoryScreen != null &&
+        !InventoryOverlayInput.isPointCovered(inventoryScreen, screenMouseX.toDouble(), screenMouseY.toDouble())
+    val scale = sackHudConfig.position.effectiveScale
+    val scaledWidth = (renderable.width * scale).roundToInt()
+    val scaledHeight = (renderable.height * scale).roundToInt()
+    val x = sackHudConfig.position.getAbsX0AllowingOverflow(scaledWidth)
+    val y = sackHudConfig.position.getAbsY0AllowingOverflow(scaledHeight)
+    val localMouseX = floor((normalMouseX - x) / scale).toInt()
+    val localMouseY = floor((normalMouseY - y) / scale).toInt()
+
+    context.nextStratum()
+    context.pose().pushMatrix()
+    context.pose().translate(x.toFloat(), y.toFloat())
+    context.pose().scale(scale, scale)
+    val localControl = renderable.renderInteractive(
+        context,
+        localMouseX.takeIf { interactive },
+        localMouseY.takeIf { interactive },
+    )
+    context.pose().popMatrix()
+
+    sackHudHovered = interactive &&
+        localMouseX in 0 until renderable.width &&
+        localMouseY in 0 until renderable.height
+    sackHudHoveredControl = localControl?.let { control ->
+        OverlayControlArea(
+            action = control.action,
+            bounds = Rect(
+                x = x + (control.bounds.x * scale).roundToInt(),
+                y = y + (control.bounds.y * scale).roundToInt(),
+                width = (control.bounds.width * scale).roundToInt().coerceAtLeast(1),
+                height = (control.bounds.height * scale).roundToInt().coerceAtLeast(1),
+            ),
+            tooltipLines = control.tooltipLines,
+        )
+    }
+    if (interactive) sackHudHoveredControl?.let { control ->
+        context.nextStratum()
+        val itemId = (control.action as? SackHudControl.Item)?.itemId
+        if (itemId != null) {
+            val entry = trackedSackHudItem(itemId)
+            SkysoftNativeTooltip.setItemActionForNextFrame(
+                context,
+                entry.stack ?: ItemStack.EMPTY,
+                null,
+                entry.name,
+                screenMouseX,
+                screenMouseY,
+                actionLines = buildList {
+                    add("§eLeft-click §7to open Bazaar")
+                    add("§eRight-click §7to remove from Sack HUD")
+                    if (SkysoftConfigGui.config().inventory.itemList.enabled) {
+                        add("§eMiddle-click §7to open Item List")
+                    }
+                },
+            )
+        } else {
+            SkysoftNativeTooltip.setForNextFrame(
+                context,
+                control.tooltipLines,
+                screenMouseX,
+                screenMouseY,
+                scrollable = false,
+            )
+        }
+    }
+}
+
+internal fun buildSackHudRenderable(inventoryOpen: Boolean): SackHudRenderable {
+    val maximumItems = sackHudConfig.settings.maximumItems.coerceIn(1, SACK_HUD_MAXIMUM_DISPLAY_ITEMS)
+    val maximumOffset = (sackHudConfig.trackedItems.size - maximumItems).coerceAtLeast(0)
+    sackHudScrollOffset = sackHudScrollOffset.coerceIn(0, maximumOffset)
+    val displayed = sackHudConfig.trackedItems
+        .asSequence()
+        .drop(sackHudScrollOffset)
+        .take(maximumItems)
+        .map(::trackedSackHudItem)
+        .toList()
+    return SackHudRenderable(
+        items = displayed,
+        hiddenAbove = sackHudScrollOffset,
+        hiddenBelow = (sackHudConfig.trackedItems.size - sackHudScrollOffset - displayed.size).coerceAtLeast(0),
+        showIcons = sackHudConfig.details.showItemIcons,
+        background = sackHudConfig.details.showBackground,
+        inventoryOpen = inventoryOpen,
+        addingItem = sackHudAddingItem && inventoryOpen,
+    )
+}
+
+internal fun trackedSackHudItem(itemId: String): SackHudItem {
+    val key = SkyBlockDataRepository.itemKey(itemId)
+    val entry = SkyBlockDataRepository.entry(key)
+    val sackData = ProfileStorageApi.storage.sackContents[itemId]
+    val name = entry?.formattedDisplayName
+        ?: sackData?.displayName?.takeIf { it.isNotBlank() }
+        ?: itemId
+    return SackHudItem(
+        itemId = itemId,
+        name = name,
+        amount = sackData?.amount ?: 0L,
+        exact = sackData?.exact == true,
+        known = sackData != null,
+        highlighted = isSackHudAmountHighlighted(itemId),
+        stack = SkyBlockDataRepository.displayStack(key),
+    )
+}
+
+private fun isSackHudAmountHighlighted(itemId: String): Boolean {
+    val expiresAt = sackHudChangeHighlights[itemId] ?: return false
+    if (System.currentTimeMillis() >= expiresAt) {
+        sackHudChangeHighlights.remove(itemId)
+        return false
+    }
+    return true
+}
+
+internal class SackHudRenderable(
+    items: List<SackHudItem>,
+    private val hiddenAbove: Int,
+    private val hiddenBelow: Int,
+    private val showIcons: Boolean,
+    private val background: Boolean,
+    private val inventoryOpen: Boolean,
+    private val addingItem: Boolean,
+) : GuiRenderable {
+    private val padding = if (background) OverlayPanelStyle.PADDING else 0
+    private val rows = items.map { item ->
+        SackHudRow(
+            item = item,
+            name = item.name.truncateLegacyText(MAXIMUM_ITEM_NAME_LENGTH),
+            value = item.displayAmount(),
+            stack = item.stack,
+            reserveIcon = showIcons,
+        )
+    }
+    private val emptyText = if (sackHudConfig.trackedItems.isEmpty()) {
+        "§7No tracked sack items."
+    } else {
+        "§7Loading item data..."
+    }
+    private val indicatorText = buildList {
+        if (hiddenAbove > 0) add("$hiddenAbove above")
+        if (hiddenBelow > 0) add("$hiddenBelow more")
+    }.joinToString(" §8• §7", prefix = "§7", postfix = if (hiddenAbove > 0 || hiddenBelow > 0) "..." else "")
+    private val addLine = if (addingItem) "§a§l[+ Click Inventory Item]" else "§e[+ Add Item]"
+    private val contentWidth = maxOf(
+        MINIMUM_WIDTH,
+        LegacyTextRenderer.width("§e§lSack HUD"),
+        rows.maxOfOrNull(SackHudRow::width) ?: LegacyTextRenderer.width(emptyText),
+        LegacyTextRenderer.width(indicatorText),
+        if (inventoryOpen) LegacyTextRenderer.width(addLine) else 0,
+    )
+
+    override val width: Int = contentWidth + padding * 2
+    override val height: Int = padding * 2 + TITLE_HEIGHT +
+        (if (rows.isEmpty()) TEXT_ROW_HEIGHT else rows.size * ITEM_ROW_HEIGHT) +
+        (if (indicatorText.isEmpty()) 0 else TEXT_ROW_HEIGHT) +
+        (if (inventoryOpen) CONTROL_ROW_HEIGHT else 0)
+
+    override fun render(context: GuiGraphicsExtractor) {
+        renderInteractive(context, null, null)
+    }
+
+    fun renderInteractive(context: GuiGraphicsExtractor, mouseX: Int?, mouseY: Int?): LocalSackHudControl? {
+        if (background) OverlayPanelStyle.draw(context, 0, 0, width, height)
+        var y = padding
+        LegacyTextRenderer.draw(context, "§e§lSack HUD", padding, y)
+        y += TITLE_HEIGHT
+        var hovered: LocalSackHudControl? = null
+        if (rows.isEmpty()) {
+            LegacyTextRenderer.draw(context, emptyText, padding, y)
+            y += TEXT_ROW_HEIGHT
+        } else {
+            rows.forEach { row ->
+                hovered = row.renderInteractive(context, padding, width - padding, y, mouseX, mouseY) ?: hovered
+                y += ITEM_ROW_HEIGHT
+            }
+        }
+        if (indicatorText.isNotEmpty()) {
+            LegacyTextRenderer.draw(context, indicatorText, (width - LegacyTextRenderer.width(indicatorText)) / 2, y)
+            y += TEXT_ROW_HEIGHT
+        }
+        if (inventoryOpen) {
+            hovered = renderAddControl(context, y, mouseX, mouseY) ?: hovered
+        }
+        return hovered
+    }
+
+    private fun renderAddControl(
+        context: GuiGraphicsExtractor,
+        y: Int,
+        mouseX: Int?,
+        mouseY: Int?,
+    ): LocalSackHudControl? {
+        val bounds = Rect(padding, y, LegacyTextRenderer.width(addLine), CONTROL_ROW_HEIGHT)
+        val hovered = mouseX != null && mouseY != null && bounds.contains(mouseX, mouseY)
+        if (hovered) {
+            context.fill(bounds.x, bounds.y, bounds.x + bounds.width, bounds.y + bounds.height, CONTROL_HOVER_COLOR)
+        }
+        LegacyTextRenderer.draw(context, addLine, bounds.x, y + CONTROL_TEXT_Y_OFFSET)
+        return LocalSackHudControl(
+            action = SackHudControl.AddItem,
+            bounds = bounds,
+            tooltipLines = listOf(
+                if (addingItem) {
+                    "§7Click an inventory item to track its sack amount."
+                } else {
+                    "§7Click, then click an inventory item to add it."
+                },
+            ),
+        ).takeIf { hovered }
+    }
+}
+
+private data class SackHudRow(
+    val item: SackHudItem,
+    val name: String,
+    val value: String,
+    val stack: ItemStack?,
+    val reserveIcon: Boolean,
+) {
+    private val contentOffset = if (reserveIcon) ITEM_TEXT_OFFSET else 0
+    val width: Int = contentOffset + LegacyTextRenderer.width(name) + COLUMN_GAP + LegacyTextRenderer.width(value)
+
+    fun renderInteractive(
+        context: GuiGraphicsExtractor,
+        left: Int,
+        right: Int,
+        y: Int,
+        mouseX: Int?,
+        mouseY: Int?,
+    ): LocalSackHudControl? {
+        val bounds = Rect(left, y, right - left, ITEM_ROW_HEIGHT)
+        val hovered = mouseX != null && mouseY != null && bounds.contains(mouseX, mouseY)
+        if (hovered) {
+            context.fill(bounds.x, bounds.y, bounds.x + bounds.width, bounds.y + bounds.height, CONTROL_HOVER_COLOR)
+        }
+        if (reserveIcon) stack?.let { ItemIconRenderable(it, ICON_SCALE).renderAt(context, left, y) }
+        LegacyTextRenderer.draw(context, name, left + contentOffset, y + ITEM_TEXT_Y_OFFSET)
+        LegacyTextRenderer.draw(context, value, right - LegacyTextRenderer.width(value), y + ITEM_TEXT_Y_OFFSET)
+        return LocalSackHudControl(SackHudControl.Item(item.itemId), bounds, emptyList()).takeIf { hovered }
+    }
+}
+
+private fun SackHudItem.displayAmount(): String {
+    val amountText = when {
+        !known -> "§8?"
+        highlighted -> "§a§l${amount.addSeparators()}"
+        !exact -> "§e~${amount.addSeparators()}"
+        else -> "§e${amount.addSeparators()}"
+    }
+    return "§7x$amountText"
+}
+
+internal data class SackHudItem(
+    val itemId: String,
+    val name: String,
+    val amount: Long,
+    val exact: Boolean,
+    val known: Boolean,
+    val highlighted: Boolean,
+    val stack: ItemStack?,
+)
+
+internal data class LocalSackHudControl(
+    val action: SackHudControl,
+    val bounds: Rect,
+    val tooltipLines: List<String>,
+)
+
+private const val MAXIMUM_ITEM_NAME_LENGTH = 30
+private const val MINIMUM_WIDTH = 160
+private const val TITLE_HEIGHT = 13
+private const val TEXT_ROW_HEIGHT = 11
+private const val ITEM_ROW_HEIGHT = 14
+private const val CONTROL_ROW_HEIGHT = 13
+private const val CONTROL_TEXT_Y_OFFSET = 1
+private const val ITEM_TEXT_Y_OFFSET = 2
+private const val ICON_SCALE = 0.75
+private const val ITEM_TEXT_OFFSET = 14
+private const val COLUMN_GAP = 8
+private const val CONTROL_HOVER_COLOR = 0x20FFFFFF

--- a/src/main/kotlin/com/skysoft/features/inventory/sacks/SackHudRender.kt
+++ b/src/main/kotlin/com/skysoft/features/inventory/sacks/SackHudRender.kt
@@ -189,10 +189,13 @@ internal class SackHudRenderable(
     } else {
         "§7Loading item data..."
     }
-    private val indicatorText = buildList {
-        if (hiddenAbove > 0) add("$hiddenAbove above")
-        if (hiddenBelow > 0) add("$hiddenBelow more")
-    }.joinToString(" §8• §7", prefix = "§7", postfix = if (hiddenAbove > 0 || hiddenBelow > 0) "..." else "")
+    private val indicatorText = when {
+        hiddenAbove <= 0 && hiddenBelow <= 0 -> ""
+        else -> buildList {
+            if (hiddenAbove > 0) add("$hiddenAbove above")
+            if (hiddenBelow > 0) add("$hiddenBelow more")
+        }.joinToString(" §8• §7", prefix = "§7", postfix = "...")
+    }
     private val addLine = if (addingItem) "§a§l[+ Click Inventory Item]" else "§e[+ Add Item]"
     private val titleText = "§e§lSack HUD"
     private val contentWidth = maxOf(

--- a/src/main/kotlin/com/skysoft/features/inventory/sacks/SackHudRender.kt
+++ b/src/main/kotlin/com/skysoft/features/inventory/sacks/SackHudRender.kt
@@ -46,9 +46,9 @@ internal fun renderSackHud(context: GuiGraphicsExtractor) {
     val interactive = inventoryScreen != null &&
         !InventoryOverlayInput.isPointCovered(inventoryScreen, screenMouseX.toDouble(), screenMouseY.toDouble())
     val scale = sackHudConfig.position.effectiveScale
-    val scaledWidth = (renderable.width * scale).roundToInt()
     val scaledHeight = (renderable.height * scale).roundToInt()
-    val x = sackHudConfig.position.getAbsX0AllowingOverflow(scaledWidth)
+    // Use width 0 so the stored X is the left edge; wider amounts grow to the right.
+    val x = sackHudConfig.position.getAbsX0AllowingOverflow(0)
     val y = sackHudConfig.position.getAbsY0AllowingOverflow(scaledHeight)
     val localMouseX = floor((normalMouseX - x) / scale).toInt()
     val localMouseY = floor((normalMouseY - y) / scale).toInt()
@@ -232,7 +232,7 @@ internal class SackHudRenderable(
             }
         }
         if (indicatorText.isNotEmpty()) {
-            LegacyTextRenderer.draw(context, indicatorText, (width - LegacyTextRenderer.width(indicatorText)) / 2, y)
+            LegacyTextRenderer.draw(context, indicatorText, padding, y)
             y += TEXT_ROW_HEIGHT
         }
         if (inventoryOpen) {
@@ -278,11 +278,14 @@ private data class SackHudRow(
     private val iconWidth = if (reserveIcon) ITEM_TEXT_OFFSET else 0
     private val nameWidth = if (name.isEmpty()) 0 else LegacyTextRenderer.width(name)
     private val valueWidth = LegacyTextRenderer.width(value)
-    val width: Int = if (compact) {
-        iconWidth + (if (reserveIcon) COMPACT_ICON_VALUE_GAP else 0) + valueWidth
-    } else {
-        iconWidth + nameWidth + COLUMN_GAP + valueWidth
+    private val afterIconGap = when {
+        !reserveIcon -> 0
+        compact || name.isEmpty() -> COMPACT_ICON_VALUE_GAP
+        else -> 0
     }
+    private val nameValueGap = if (name.isNotEmpty()) COLUMN_GAP else 0
+    private val valueXOffset = iconWidth + afterIconGap + nameWidth + nameValueGap
+    val width: Int = valueXOffset + valueWidth
 
     fun renderInteractive(
         context: GuiGraphicsExtractor,
@@ -292,8 +295,7 @@ private data class SackHudRow(
         mouseX: Int?,
         mouseY: Int?,
     ): LocalSackHudControl? {
-        val rowRight = if (compact) left + width else right
-        val bounds = Rect(left, y, (rowRight - left).coerceAtLeast(1), ITEM_ROW_HEIGHT)
+        val bounds = Rect(left, y, (right - left).coerceAtLeast(1), ITEM_ROW_HEIGHT)
         val hovered = mouseX != null && mouseY != null && bounds.contains(mouseX, mouseY)
         if (hovered) {
             context.fill(bounds.x, bounds.y, bounds.x + bounds.width, bounds.y + bounds.height, CONTROL_HOVER_COLOR)
@@ -302,12 +304,8 @@ private data class SackHudRow(
         if (name.isNotEmpty()) {
             LegacyTextRenderer.draw(context, name, left + iconWidth, y + ITEM_TEXT_Y_OFFSET)
         }
-        val valueX = if (compact) {
-            left + iconWidth + if (reserveIcon) COMPACT_ICON_VALUE_GAP else 0
-        } else {
-            rowRight - valueWidth
-        }
-        LegacyTextRenderer.draw(context, value, valueX, y + ITEM_TEXT_Y_OFFSET)
+        // Amounts are left-flowing after the icon/name so extra digits grow to the right.
+        LegacyTextRenderer.draw(context, value, left + valueXOffset, y + ITEM_TEXT_Y_OFFSET)
         return LocalSackHudControl(SackHudControl.Item(item.itemId), bounds, emptyList()).takeIf { hovered }
     }
 }


### PR DESCRIPTION
Fix: isSackHudVisable() display now doesn't appear in the position editor when the display is not visible
Fix: Stays visible in inventories when "hide when empty" setting is turned on, so you can still add items to be tracked 
Change: Name changed to "Sacks Tracker" from "Sack Hud"

Note: I tried multiple approaches to reuse the present code for the Sack Display feature and ended up with more files and even more lines of code. 

Added: Left-justified the text in the GUI box. Was not liking the updating of item collection into sacks messing with where you have the HUD placed on your screen. 
Fix: When the background is enabled, an empty row after the last item you have saved to track is present when it shouldn't be.