### PR TITLE
Fix:Disable Chat Peek while inventories or sign input screens are open.

### DIFF
--- a/src/main/kotlin/com/skysoft/features/chat/ChatPeek.kt
+++ b/src/main/kotlin/com/skysoft/features/chat/ChatPeek.kt
@@ -1,15 +1,20 @@
 package com.skysoft.features.chat
 
 import com.skysoft.config.SkysoftConfigGui
+import com.skysoft.utils.MinecraftClient
 import com.skysoft.utils.input.InputUtilities
 import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.components.ChatComponent
+import net.minecraft.client.gui.screens.Screen
+import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen
+import net.minecraft.client.gui.screens.inventory.AbstractSignEditScreen
 import org.lwjgl.glfw.GLFW
 
 internal enum class ChatPeekState {
     DISABLED,
     NO_PLAYER,
     KEY_UNBOUND,
+    SCREEN_OPEN,
     KEY_RELEASED,
     ACTIVE,
 }
@@ -37,8 +42,14 @@ internal object ChatPeek {
             key = key,
             hasPlayer = { Minecraft.getInstance().player != null },
             isKeyDown = { InputUtilities.isBindingDown(key) },
+            isPeekBlocked = { isChatPeekBlocked() },
         )
     }
+}
+
+internal fun isChatPeekBlocked(screen: Screen? = MinecraftClient.screen()): Boolean = when (screen) {
+    is AbstractContainerScreen<*>, is AbstractSignEditScreen -> true
+    else -> false
 }
 
 internal inline fun chatPeekState(
@@ -46,10 +57,12 @@ internal inline fun chatPeekState(
     key: Int,
     hasPlayer: () -> Boolean,
     isKeyDown: () -> Boolean,
+    isPeekBlocked: () -> Boolean,
 ): ChatPeekState = when {
     !isEnabled -> ChatPeekState.DISABLED
     !hasPlayer() -> ChatPeekState.NO_PLAYER
     key == GLFW.GLFW_KEY_UNKNOWN -> ChatPeekState.KEY_UNBOUND
+    isPeekBlocked() -> ChatPeekState.SCREEN_OPEN
     !isKeyDown() -> ChatPeekState.KEY_RELEASED
     else -> ChatPeekState.ACTIVE
 }


### PR DESCRIPTION
Prevent the peek key from expanding chat in the background when typing in Item List search, any container GUI, or Hypixel bazaar/auction sign search.

From feature request: https://discord.com/channels/384340624524050432/1543257142696611932