### PR TITLE
Fix Vertex's Id Max Conflict

### DIFF
--- a/src/target26_1/kotlin/com/skysoft/utils/render/shader/SkysoftVertexFormats.kt
+++ b/src/target26_1/kotlin/com/skysoft/utils/render/shader/SkysoftVertexFormats.kt
@@ -9,19 +9,14 @@ import com.mojang.blaze3d.vertex.VertexFormatElement
 import org.lwjgl.system.MemoryUtil
 
 object SkysoftVertexFormats {
-    private val lastRegisteredId by lazy {
-        (0 until VertexFormatElement.MAX_COUNT).filter { VertexFormatElement.byId(it) != null }.max()
-    }
-
     enum class VertexElement {
         ROUNDED_PARAMS_0,
         ROUNDED_PARAMS_1,
         CONTOUR_UV_BOUNDS,
         ;
 
-        private val registrationId: Int by lazy { lastRegisteredId + ordinal + 1 }
         val element: VertexFormatElement by lazy {
-            safeRegister(registrationId)
+            safeRegister()
         }
     }
 
@@ -43,8 +38,8 @@ object SkysoftVertexFormats {
             .build()
     }
 
-    private fun safeRegister(desiredId: Int): VertexFormatElement {
-        val id = (desiredId until VertexFormatElement.MAX_COUNT).first { VertexFormatElement.byId(it) == null }
+    private fun safeRegister(): VertexFormatElement {
+        val id = (0 until VertexFormatElement.MAX_COUNT).first { VertexFormatElement.byId(it) == null }
         return VertexFormatElement.register(id, 0, VertexFormatElement.Type.FLOAT, false, PARAMETER_COMPONENT_COUNT)
     }
 


### PR DESCRIPTION
This PR fixes the conflict that might arise with the previous Skysoft vertex ID searcher and other mods.

What happened?
Skysoft started randomly crashing itself after adding a new mod, MusicDisplay. Basically, MusicDisplay [took an approach to check for a free vertex id's from the top, 31 to 0](https://github.com/realmichaelstetson/musicdisplay/blob/0c083fbac8d519cbf90f7b51a850ea95a6359eaf/src/client/java/com/haloclient/client/render/HaloRenderPipelines.java#L19-L27). Skysoft took a separate approach to take the next id after the maximum one. The maximum id is 31, so 31+1 made it crash, always, as MusicDisplay took the id 31 for itself.

This PR changes the algorithm to simply go from 7 (actually 0, but 0-7 are used by Vanilla) to 31, taking a free id, which resolves this edge case. It stopped crashing for me. I only hope it won't cause any other unforeseen issues.